### PR TITLE
Reduce docker image size and update to 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu
+FROM debian:wheezy
 
 MAINTAINER f99aq8ove <f99aq8ove [at] gmail.com>
 
-RUN apt-get update
-RUN apt-get install -q -y openjdk-7-jre-headless
-RUN apt-get clean
-
+RUN apt-get update && \
+    apt-get install -q -y openjdk-7-jre-headless && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ADD https://github.com/takezoe/gitbucket/releases/download/2.8/gitbucket.war /opt/gitbucket.war
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ADD https://github.com/takezoe/gitbucket/releases/download/2.8/gitbucket.war /opt/gitbucket.war
+ADD https://github.com/takezoe/gitbucket/releases/download/3.0/gitbucket.war /opt/gitbucket.war
 
 RUN ln -s /gitbucket /root/.gitbucket
 


### PR DESCRIPTION
This request includes the following change

- reduce docker image size by following [this instruction](http://www.centurylinklabs.com/optimizing-docker-images/)
- download gitbucket3.0
