### PR TITLE
Add force install of OpenJDK dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER f99aq8ove <f99aq8ove [at] gmail.com>
 
 RUN apt-get update && \
     apt-get upgrade -q -y && \
-    apt-get install -q -y --no-install-recommends openjdk-7-jre-headless && \
+    apt-get install -q -y --force-yes --no-install-recommends openjdk-7-jre-headless && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
For some reason, last time I tried to build this image, this happened somewhere along in the build:

```bash
WARNING: The following packages cannot be authenticated!
  tzdata-java
E: There are problems and -y was used without --force-yes
INFO[0017] The command [/bin/sh -c apt-get update &&     apt-get upgrade -q -y &&     apt-get install -q -y --no-install-recommends openjdk-7-jre-headless &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*] returned a non-zero code: 100 
```
I'm not sure if we can trust `tzdata-java` or not, but I don't have any other solution on hand.