### PR TITLE
Consider default jre instead of Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:jre-alpine
+FROM java:jre
 
 MAINTAINER f99aq8ove <f99aq8ove [at] gmail.com>
 


### PR DESCRIPTION
Fails to resolve cross-container hostnames in Kubernetes clusters.

https://groups.google.com/forum/#!msg/google-containers/oxRNHFr7jm0/z-YPM0wyxUQJ

Any specific reasons to stick with Alpine? Maybe a gitbucket:alpine tag would do?