### PR TITLE
Add environment variables to configure GitBucket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER f99aq8ove <f99aq8ove [at] gmail.com>
 
 ADD https://github.com/gitbucket/gitbucket/releases/download/4.4/gitbucket.war /opt/gitbucket.war
 
+COPY gitbucket.sh /opt/gitbucket.sh
+
 RUN ln -s /gitbucket /root/.gitbucket
 
 VOLUME /gitbucket
@@ -13,4 +15,4 @@ EXPOSE 8080
 # Port for SSH access to git repository (Optional)
 EXPOSE 29418
 
-CMD ["java", "-jar", "/opt/gitbucket.war"]
+CMD ["/opt/gitbucket.sh"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ In order to access the git repository over SSH (port 29418), check settings belo
 
 - GitBucket > Administration > System Settings > SSH access
 
+Additional environment variables can be set as below.
+
+Environment variable | Value | Example
+---------------------|-------|--------
+`GITBUCKET_DB_URL`, `GITBUCKET_DB_USER`, `GITBUCKET_DB_PASSWORD` | Database connection for MySQL or PostgreSQL. See [External database configuration](https://github.com/gitbucket/gitbucket/wiki/External-database-configuration). Defaults to H2. | `jdbc:postgresql://db/gitbucket`, `user`, `password`
+`JAVA_OPTS`         | JavaVM options.     | `-Xmx1g`
+`GITBUCKET_OPTS`    | GitBucket options.  | `--prefix=/gitbucket`
+
 ## Building
 
 To build the image, do the following:

--- a/gitbucket.sh
+++ b/gitbucket.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -xe
+
+if [ "$GITBUCKET_DB_URL" -a "$GITBUCKET_DB_USER" -a "$GITBUCKET_DB_PASSWORD" ]; then
+  cat > /gitbucket/database.conf <<-EOCONF
+db {
+  url = "$GITBUCKET_DB_URL"
+  user = "$GITBUCKET_DB_USER"
+  password = "$GITBUCKET_DB_PASSWORD"
+}
+EOCONF
+fi
+
+exec java $JAVA_OPTS -jar /opt/gitbucket.war $GITBUCKET_OPTS


### PR DESCRIPTION
This pull request adds the feature to configure GitBucket such as the external database, JavaVM option and GitBucket option by environment variables.

Thanks for the great work.