### PR TITLE
Add Functionality to system packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM openjdk:jre
 MAINTAINER f99aq8ove <f99aq8ove [at] gmail.com>
 
 ENV GITBUCKET_VER 4.24.0
+ENV GITBUCKET_EXTRA_DEPS "git procps"
+
 ADD https://github.com/gitbucket/gitbucket/releases/download/$GITBUCKET_VER/gitbucket.war /opt/gitbucket.war
 
 RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Environment variable | Value | Example
 `JAVA_OPTS`         | JavaVM options.     | `-Xmx1g`
 `GITBUCKET_OPTS`    | GitBucket options.  | `--prefix=/gitbucket`
 `GITBUCKET_CERT`    | LDAP Authentication certificate path.  Embed a certificate to container. See [LDAP Authentication Settings](https://github.com/gitbucket/gitbucket/wiki/LDAP-Authentication-Settings)  | `/var/lib/samba/private/tls/cert.pem`
+`GITBUCKET_EXTRA_DEPS`    | system dependencies required by gitbucket plugins.     | `git procps`
 
 ## Building
 

--- a/gitbucket.sh
+++ b/gitbucket.sh
@@ -27,4 +27,14 @@ if [ "$GITBUCKET_CERT" ]; then
   fi
 fi
 
+# Add support to install system utils that are required by some gitbucket plugins
+if [ "$GITBUCKET_EXTRA_DEPS" ]
+  then
+	apt-get update 
+	apt-get upgrade -y 
+	apt-get install --no-install-recommends -y $GITBUCKET_EXTRA_DEPS
+    apt-get clean 
+	rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+fi
+
 exec java $JAVA_OPTS -jar /opt/gitbucket.war $GITBUCKET_OPTS


### PR DESCRIPTION
 if GITBUCKET_EXTRA_DEPS is set apt-get install is being executed with it's arguments.
=====
Allows to install some system software, so upgrading a version, that has plugins that relies on system tools (git, ps...) have them, without manual tweaking of each instance