### PR TITLE
Locks JRE at Java 8, in order to keep X-HUB-Tokens working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:jre-alpine
+FROM openjdk:8-jre-alpine
 
 MAINTAINER f99aq8ove <f99aq8ove [at] gmail.com>
 


### PR DESCRIPTION
Right now, Tokens rely on java being able to serialize xml
https://github.com/gitbucket/gitbucket/blob/4.31.1/src/main/scala/gitbucket/core/service/WebHookService.scala#L266